### PR TITLE
Update documentation URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ analog to Python's NumPy library. Later we found that kotlin is much more flexib
 architecture designs. In contrast to `numpy` and `scipy` it is modular and has a lightweight core. The `numpy`-like
 experience could be achieved with [kmath-for-real](/kmath-for-real) extension module.
 
-[Documentation site (**WIP**)](https://mipt-npm.github.io/kmath/)
+[Documentation site (**WIP**)](https://sciprogcentre.github.io/kmath/)
 
 ## Publications and talks
 


### PR DESCRIPTION
The documentation site URL seems to be outdated. Here's an updated version.