### PR TITLE
Update `kmath-kotlingrad` features references

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,8 +170,8 @@ One can still use generic algebras though.
 > **Maturity**: EXPERIMENTAL
 >
 > **Features:**
-> - [differentiable-mst-expression](kmath-kotlingrad/src/main/kotlin/space/kscience/kmath/kotlingrad/KotlingradExpression.kt) : MST based DifferentiableExpression.
-> - [scalars-adapters](kmath-kotlingrad/src/main/kotlin/space/kscience/kmath/kotlingrad/scalarsAdapters.kt) : Conversions between Kotlin∇'s SFun and MST
+> - [differentiable-mst-expression](kmath-kotlingrad/src/jvmMain/kotlin/space/kscience/kmath/kotlingrad/KotlingradExpression.kt) : MST based DifferentiableExpression.
+> - [scalars-adapters](kmath-kotlingrad/src/jvmMain/kotlin/space/kscience/kmath/kotlingrad/scalarsAdapters.kt) : Conversions between Kotlin∇'s SFun and MST
 
 
 ### [kmath-memory](kmath-memory)


### PR DESCRIPTION
# PR Summary
Small PR - Commit 7064546f835dd8870df0d1482ff76557bfadbef9 renamed `kmath-kotlingrad/src/main` to be `kmath-kotlingrad/src/jvmMain`. This PR adjusts sources to changes.